### PR TITLE
End package.json with newline

### DIFF
--- a/src/sortPackageJson.ts
+++ b/src/sortPackageJson.ts
@@ -12,7 +12,7 @@ export function sortPackageJson(textEditor: TextEditor, edit: TextEditorEdit) {
 
   if (json) {
     const sort = getSortFn(json, textEditor.document.fileName)
-    edit.replace(getWholeTextRange(textEditor), JSON.stringify(sort(json), null, 2))
+    edit.replace(getWholeTextRange(textEditor), JSON.stringify(sort(json), null, 2) + '\n')
   }
 }
 

--- a/src/sortPackageJson.ts
+++ b/src/sortPackageJson.ts
@@ -12,7 +12,12 @@ export function sortPackageJson(textEditor: TextEditor, edit: TextEditorEdit) {
 
   if (json) {
     const sort = getSortFn(json, textEditor.document.fileName)
-    edit.replace(getWholeTextRange(textEditor), JSON.stringify(sort(json), null, 2) + '\n')
+    const text = getWholeTextRange(textEditor)
+    edit.replace(text, JSON.stringify(sort(json), null, 2))
+    // insert newline if previously present
+    if (text.end.character === 0) {
+      edit.insert(text.end, '\n')
+    }
   }
 }
 


### PR DESCRIPTION
It is common to end `package.json` with a newline character. This is how `npm init` does it anyway.

This extension itself has an ending newline character in `package.json` as well.