### PR TITLE
Fix CodeAction

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
       }
     ]
   },
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "dependencies": {
     "read-pkg-up": "^7.0.1",
     "resolve": "^1.22.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,9 +4,7 @@ import { sortPackageJson } from './sortPackageJson'
 
 export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
-		vscode.commands.registerTextEditorCommand('editor.sortPackageJson', sortPackageJson)
-	)
-	context.subscriptions.push(
+		vscode.commands.registerTextEditorCommand('editor.sortPackageJson', sortPackageJson),
 		vscode.languages.registerCodeActionsProvider(
 			{ language: 'json', pattern: '**/package.json' },
 			new CodeActionProvider()
@@ -16,15 +14,14 @@ export function activate(context: vscode.ExtensionContext) {
 
 export class CodeActionProvider implements vscode.CodeActionProvider {
 	public provideCodeActions() {
-		return [
-			{
-				title: 'Sort well-known keys in package.json',
-				kind: vscode.CodeActionKind.SourceFixAll,
-				command: {
-					title: 'Sort well-known keys in package.json',
-					command: 'editor.sortPackageJson'
-				}
-			}
-		]
+		const sortPackageJsonCodeAction = new vscode.CodeAction(
+			'Sort well-known keys in package.json',
+			vscode.CodeActionKind.Source.append('sortPackageJson')
+		)
+		sortPackageJsonCodeAction.command = {
+			command: 'editor.sortPackageJson',
+			title: 'Sort well-known keys in package.json'
+		}
+		return [sortPackageJsonCodeAction]
 	}
 }


### PR DESCRIPTION
Fix CodeAction introduced in #68

New config for `Settings (json)`:

```json5
  // Sort package.json keys
  "editor.codeActionsOnSave": ["source.sortPackageJson"],
```